### PR TITLE
Use gtihubLogin as org ID in all cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Use the correct orgid when starting a new chat
+
 ## [0.3.3] - 2025-03-13
 
 ### Fixed

--- a/src/copilot.ts
+++ b/src/copilot.ts
@@ -157,7 +157,7 @@ export class Handler implements vscode.ChatFollowupProvider {
         case 0:
           throw new Error("You are not a member of any Pulumi organizations.");
         case 1:
-          chatState.orgId = userInfo.organizations[0].name;
+          chatState.orgId = userInfo.organizations[0].githubLogin;
           break;
         default: {
           // present a pick list to select an organization


### PR DESCRIPTION

A fix to use `githubLogin` rather than `name` as the orgid.

Closes #10 
